### PR TITLE
chore: update persisted state to follow best practices

### DIFF
--- a/src/frontend/contexts/IntlContext.tsx
+++ b/src/frontend/contexts/IntlContext.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import {IntlProvider as IntlProviderOrig, CustomFormats} from 'react-intl';
-import {getLocales} from 'expo-localization';
 
-import {createPersistedState} from '../hooks/usePersistedState';
 import messages from '../translations/messages.json';
 import languages from '../languages.json';
+import {usePersistedLocale} from '../hooks/persistedState/usePersistedLocale';
 
 export const formats: CustomFormats = {
   date: {
@@ -54,12 +53,8 @@ a language name and translations in \`src/frontend/languages.json\``,
     return a.englishName.localeCompare(b.englishName);
   });
 
-const usePersistedState = createPersistedState('MapeoLocale');
-
 export const IntlProvider = ({children}: {children: React.ReactNode}) => {
-  const [appLocale, setLocale] = usePersistedState<string>(
-    getSupportedLocale(getLocales()[0].languageTag) || 'en',
-  );
+  const appLocale = usePersistedLocale(store => store.locale);
 
   const languageCode = appLocale.split('-')[0];
 
@@ -90,7 +85,7 @@ function onError(e: Error) {
 // translations for `en`. If we don't have translations for a given device
 // language, then we ignore it and fallback to `en` or the user selected
 // language for the app
-function getSupportedLocale(
+export function getSupportedLocale(
   locale: string,
 ): keyof typeof languages | undefined {
   if (supportedLanguages.find(lang => lang.locale === locale))

--- a/src/frontend/hooks/persistedState/createPersistedState.ts
+++ b/src/frontend/hooks/persistedState/createPersistedState.ts
@@ -9,7 +9,7 @@ import {MMKV} from 'react-native-mmkv';
 
 const storage = new MMKV();
 
-type PersistedStoreKey = 'test' | 'MapeoLocale';
+type PersistedStoreKey = 'MapeoLocale';
 
 const MMKVZustandStorage: StateStorage = {
   setItem: (name, value) => {
@@ -24,17 +24,27 @@ const MMKVZustandStorage: StateStorage = {
   },
 };
 
-function createPersistedState<T>(
+/**
+ * alskdfasdf
+ */
+type MigrationOpt<T> =
+  | {version: number; migrateFn: PersistOptions<T, T>['migrate']}
+  | {version: number};
+
+export function createPersistedState<T>(
   slice: StateCreator<T>,
   persistedStoreKey: PersistedStoreKey,
-  migrationOpt?: {version: number; migrateFn: PersistOptions<T, T>['migrate']},
+  migrationOpt?: MigrationOpt<T>,
 ) {
   return create<T, [['zustand/persist', T]]>(
     persist(slice, {
       name: persistedStoreKey,
       storage: createJSONStorage(() => MMKVZustandStorage),
       version: migrationOpt?.version,
-      migrate: migrationOpt?.migrateFn,
+      migrate:
+        migrationOpt && 'migrateFn' in migrationOpt
+          ? migrationOpt.migrateFn
+          : undefined,
     }),
   );
 }

--- a/src/frontend/hooks/persistedState/createPersistedState.ts
+++ b/src/frontend/hooks/persistedState/createPersistedState.ts
@@ -24,9 +24,6 @@ const MMKVZustandStorage: StateStorage = {
   },
 };
 
-/**
- * alskdfasdf
- */
 type MigrationOpt<T> =
   | {version: number; migrateFn: PersistOptions<T, T>['migrate']}
   | {version: number};

--- a/src/frontend/hooks/persistedState/usePersistedLocale.ts
+++ b/src/frontend/hooks/persistedState/usePersistedLocale.ts
@@ -1,0 +1,14 @@
+import {StateCreator} from 'zustand';
+import {createPersistedState} from './createPersistedState';
+
+type LocaleSlice = {
+  locale: string;
+  setLocale: (locale: string) => void;
+};
+
+const localeSlice: StateCreator<LocaleSlice> = (set, get) => ({
+  locale: 'en',
+  setLocale: newlocale => set({locale: newlocale}),
+});
+
+export const usePersistedLocale = createPersistedState(localeSlice, 'MapeoLocale');

--- a/src/frontend/hooks/persistedState/usePersistedLocale.ts
+++ b/src/frontend/hooks/persistedState/usePersistedLocale.ts
@@ -1,5 +1,7 @@
 import {StateCreator} from 'zustand';
 import {createPersistedState} from './createPersistedState';
+import {getSupportedLocale} from '../../contexts/IntlContext';
+import {getLocales} from 'expo-localization';
 
 type LocaleSlice = {
   locale: string;
@@ -7,8 +9,11 @@ type LocaleSlice = {
 };
 
 const localeSlice: StateCreator<LocaleSlice> = (set, get) => ({
-  locale: 'en',
+  locale: getSupportedLocale(getLocales()[0].languageTag) || 'en',
   setLocale: newlocale => set({locale: newlocale}),
 });
 
-export const usePersistedLocale = createPersistedState(localeSlice, 'MapeoLocale');
+export const usePersistedLocale = createPersistedState(
+  localeSlice,
+  'MapeoLocale',
+);


### PR DESCRIPTION
Updated persisted store to not be statically created. Previous implementation (which followed Mapeo Mobile), meant that the persisted store was being dynamically created. This dynamic creation meant that a context was still need to propagate the state to the rest of the app, going against zustand best practices.

While this will mean more refactoring, I think this will come with an obvious benefit of a more simplified code and persisted store implementation!